### PR TITLE
feat : invoked clear content method in editor when

### DIFF
--- a/lib/components/Tapwrite.tsx
+++ b/lib/components/Tapwrite.tsx
@@ -150,6 +150,11 @@ export const Editor = ({
   });
 
   useEffect(() => {
+    if (content == "") {
+      editor?.commands.clearContent();
+    }
+  }, [editor, content]);
+  useEffect(() => {
     if (editor) {
       editor.storage.MentionStorage.suggestions = suggestions;
     }


### PR DESCRIPTION
1. content is passed as empty string
2. adding useeffect here might be not so optimized but the cases where content == '' will be very unlikely because normally the contents are '<p> </p'.